### PR TITLE
Fix for a bug when generating Portal Hubs

### DIFF
--- a/src/main/java/io/github/vampirestudios/raa/utils/JsonConverter.java
+++ b/src/main/java/io/github/vampirestudios/raa/utils/JsonConverter.java
@@ -72,11 +72,11 @@ public class JsonConverter {
                 if (name.equals("palette")) {
                     JsonArray list = JsonHelper.getArray(valueArray, "list");
                     list.forEach(jsonElement1 -> {
+                        Map<String, String> blockPropertyMap = new HashMap<>();
                         JsonArray paletteProperties = jsonElement1.getAsJsonArray();
                         paletteProperties.forEach(jsonElement2 -> {
                             JsonObject paletteProperty = jsonElement2.getAsJsonObject();
                             String propertyName = JsonHelper.getString(paletteProperty, "name");
-                            Map<String, String> blockPropertyMap = new HashMap<>();
                             if (propertyName.equals("Name")) {
                                 structure.setBlockProperties(blockPropertyMap);
                                 String blockId = JsonHelper.getString(paletteProperty, "value");

--- a/src/main/java/io/github/vampirestudios/raa/utils/WorldStructureManipulation.java
+++ b/src/main/java/io/github/vampirestudios/raa/utils/WorldStructureManipulation.java
@@ -175,21 +175,21 @@ public class WorldStructureManipulation {
                     world.setBlockState(pos, world.getBlockState(pos).with(Properties.CHEST_TYPE, ChestType.valueOf(properties.get("type"))), 2);
                 } else {
                     //TODO: [Slabs]
-                    world.setBlockState(pos, world.getBlockState(pos).with(Properties.SLAB_TYPE, SlabType.valueOf(properties.get("type"))), 2);
+                    world.setBlockState(pos, world.getBlockState(pos).with(Properties.SLAB_TYPE, SlabType.valueOf(properties.get("type").toUpperCase())), 2);
                 }
             } if (properties.get("half") != null) {
                 //TODO: [Stairs]
-                world.setBlockState(pos, world.getBlockState(pos).with(Properties.BLOCK_HALF, BlockHalf.valueOf(properties.get("half"))), 2);
+                world.setBlockState(pos, world.getBlockState(pos).with(Properties.BLOCK_HALF, BlockHalf.valueOf(properties.get("half").toUpperCase())), 2);
             } if (properties.get("shape") != null) {
                 //TODO: [Stairs]
-                world.setBlockState(pos, world.getBlockState(pos).with(Properties.STAIR_SHAPE, StairShape.valueOf(properties.get("shape"))), 2);
+                world.setBlockState(pos, world.getBlockState(pos).with(Properties.STAIR_SHAPE, StairShape.valueOf(properties.get("shape").toUpperCase())), 2);
             } if (properties.get("facing") != null) {
                 if (block.equals("minecraft:barrel")) {
                     //TODO: Barrel
-                    world.setBlockState(pos, world.getBlockState(pos).with(Properties.FACING, Direction.valueOf(facing)), 2);
+                    world.setBlockState(pos, world.getBlockState(pos).with(Properties.FACING, Direction.valueOf(facing.toUpperCase())), 2);
                 } else {
                     //TODO: [Anvils], [Chests], [Stairs], Bell, Blast_Furnace, Furnace, Grindstone, Smoker, Stonecutter,
-                    world.setBlockState(pos, world.getBlockState(pos).with(Properties.HORIZONTAL_FACING, Direction.valueOf(facing)), 2);
+                    world.setBlockState(pos, world.getBlockState(pos).with(Properties.HORIZONTAL_FACING, Direction.valueOf(facing.toUpperCase())), 2);
                 }
             } if (properties.get("north") != null || properties.get("west") != null || properties.get("south") != null || properties.get("east") != null) {
                 //TODO: [Fences], [Walls], Iron bar

--- a/src/main/java/io/github/vampirestudios/raa/utils/WorldStructureManipulation.java
+++ b/src/main/java/io/github/vampirestudios/raa/utils/WorldStructureManipulation.java
@@ -223,13 +223,13 @@ public class WorldStructureManipulation {
                 world.setBlockState(pos, world.getBlockState(pos).with(Properties.UNSTABLE, properties.get("unstable").equals("TRUE")), 2);
             } if (properties.get("face") != null) {
                 //TODO: Grindstone
-                world.setBlockState(pos, world.getBlockState(pos).with(Properties.WALL_MOUNT_LOCATION, WallMountLocation.valueOf(properties.get("face"))), 2);
+                world.setBlockState(pos, world.getBlockState(pos).with(Properties.WALL_MOUNT_LOCATION, WallMountLocation.valueOf(properties.get("face").toUpperCase())), 2);
             } if (properties.get("distance") != null) {
                 //TODO: Scaffolding
                 world.setBlockState(pos, world.getBlockState(pos).with(Properties.DISTANCE_0_7, Integer.parseInt(properties.get("distance"))), 2);
             } if (properties.get("attachment") != null) {
                 //TODO: Bell
-                world.setBlockState(pos, world.getBlockState(pos).with(Properties.ATTACHMENT, Attachment.valueOf(properties.get("attachment"))), 2);
+                world.setBlockState(pos, world.getBlockState(pos).with(Properties.ATTACHMENT, Attachment.valueOf(properties.get("attachment").toUpperCase())), 2);
             } if (properties.get("axis") != null) {
                 //TODO: Bone_Block
                 world.setBlockState(pos, world.getBlockState(pos).with(Properties.AXIS, Direction.Axis.fromName(axis)), 2);


### PR DESCRIPTION
Previously when generating Portal Hubs, the method loadStructure from the class JsonConverter was called. Inside this method it should parse the properties of the blocks of the palette. But because of a scope-issue inside nested lambda-expressions the parsed values would be dereferenced before they were saved. Also the code responsible for setting block states inside the placeBlock method of the WorldStructureManipulation class was flawed in a way, that it tried to lookup values in an enum before capitalizing them.