### PR TITLE
Followup on #85

### DIFF
--- a/src/main/java/io/github/vampirestudios/raa/generation/feature/portalHub/PortalHubFeature.java
+++ b/src/main/java/io/github/vampirestudios/raa/generation/feature/portalHub/PortalHubFeature.java
@@ -65,10 +65,14 @@ public class PortalHubFeature extends Feature<DefaultFeatureConfig> {
                         } else {
                             currBlockProp.remove("up");
                             currBlockProp.replaceAll((name, value) -> {
-                                if((name.equals("north") || name.equals("west") || name.equals("south") || name.equals("east")) && value.toUpperCase().equals("NONE")) {
-                                    return "false";
+                                if(name.equals("north") || name.equals("west") || name.equals("south") || name.equals("east")) {
+                                    if (value.toUpperCase().equals("NONE") || value.toUpperCase().equals("FALSE")) {
+                                        return "false";
+                                    } else {
+                                        return "true";
+                                    }
                                 } else {
-                                    return "true";
+                                    return value;
                                 }
                             });
                             WorldStructureManipulation.placeBlock(world, pos.add(currBlockPos), Registry.BLOCK.getId(theme.getWall()).toString(), currBlockProp, 0);

--- a/src/main/java/io/github/vampirestudios/raa/generation/feature/portalHub/PortalHubFeature.java
+++ b/src/main/java/io/github/vampirestudios/raa/generation/feature/portalHub/PortalHubFeature.java
@@ -64,6 +64,13 @@ public class PortalHubFeature extends Feature<DefaultFeatureConfig> {
                             WorldStructureManipulation.placeBlock(world, pos.add(currBlockPos), Registry.BLOCK.getId(theme.getWall()).toString(), new HashMap<>(), 0);
                         } else {
                             currBlockProp.remove("up");
+                            currBlockProp.replaceAll((name, value) -> {
+                                if((name.equals("north") || name.equals("west") || name.equals("south") || name.equals("east")) && value.toUpperCase().equals("NONE")) {
+                                    return "false";
+                                } else {
+                                    return "true";
+                                }
+                            });
                             WorldStructureManipulation.placeBlock(world, pos.add(currBlockPos), Registry.BLOCK.getId(theme.getWall()).toString(), currBlockProp, 0);
                         }
                         break;

--- a/src/main/java/io/github/vampirestudios/raa/utils/WorldStructureManipulation.java
+++ b/src/main/java/io/github/vampirestudios/raa/utils/WorldStructureManipulation.java
@@ -207,10 +207,10 @@ public class WorldStructureManipulation {
             } if (properties.get("north") != null || properties.get("west") != null || properties.get("south") != null || properties.get("east") != null) {
                 if(!block.endsWith("_wall")) {
                     //Fences and Iron Bars, both use booleans to represent their connection
-                    world.setBlockState(pos, world.getBlockState(pos).with(Properties.NORTH, directions.getOrDefault("north", "FALSE").equals("TRUE")), 2);
-                    world.setBlockState(pos, world.getBlockState(pos).with(Properties.WEST, directions.getOrDefault("west", "FALSE").equals("TRUE")), 2);
-                    world.setBlockState(pos, world.getBlockState(pos).with(Properties.SOUTH, directions.getOrDefault("south", "FALSE").equals("TRUE")), 2);
-                    world.setBlockState(pos, world.getBlockState(pos).with(Properties.EAST, directions.getOrDefault("east", "FALSE").equals("TRUE")), 2);
+                    world.setBlockState(pos, world.getBlockState(pos).with(Properties.NORTH, directions.getOrDefault("north", "FALSE").toUpperCase().equals("TRUE")), 2);
+                    world.setBlockState(pos, world.getBlockState(pos).with(Properties.WEST, directions.getOrDefault("west", "FALSE").toUpperCase().equals("TRUE")), 2);
+                    world.setBlockState(pos, world.getBlockState(pos).with(Properties.SOUTH, directions.getOrDefault("south", "FALSE").toUpperCase().equals("TRUE")), 2);
+                    world.setBlockState(pos, world.getBlockState(pos).with(Properties.EAST, directions.getOrDefault("east", "FALSE").toUpperCase().equals("TRUE")), 2);
                 } else {
                     //Walls use an Enum (none, tall, low) to describe their connections to other neighbouring blocks
                     world.setBlockState(pos, world.getBlockState(pos).with(Properties.NORTH_WALL_SHAPE, WallShape.valueOf(directions.getOrDefault("north","none").replace("false","none").replace("true","low").toUpperCase())), 2);


### PR DESCRIPTION
With the changes on the WorldStructureManipulation introduced in previous commits, fences needed special treatment as they are replacing walls in the theme-specific palettes but dont share exactly the same properties. Also added missing toUpperCase for sanitizing input.
This will hopefully be the last PR regarding walls, not a lot left that could be faulty.